### PR TITLE
Add alignment training mode with conserved node contrastive loss

### DIFF
--- a/src/ginfinity/scripts/scripts_README.md
+++ b/src/ginfinity/scripts/scripts_README.md
@@ -172,21 +172,22 @@ The default `--output-dir` is `windows_output/`.
 
 ## train_model.py
 
-**Purpose**  
-Train a GIN on RNA embeddings using triplet loss, with optional hyperparameter tuning via Optuna.
+**Purpose**
+Train a GIN on RNA secondary structures. Supported training modes include:
 
-**Usage**
-```bash
-python train_model.py \\
-  --train-data <train.tsv> \\
-  --val-data <val.tsv> \\
-  [--batch-size N] \\
-  [--epochs N] \\
-  [--lr FLOAT] \\
-  [--early-stopping-patience N] \\
-  [--output-model <out.pth>] \\
-  [--quiet]
-```
+- `triplet`: original triplet-loss optimisation using anchor/positive/negative structures.
+- `regression`: cosine-distance regression against a scalar target.
+- `alignment`: contrastive training on simulated evolutionary alignments with conserved node mappings.
+
+**Key arguments**
+
+- `--training_mode {triplet,regression,alignment}`: select the optimisation objective.
+- `--alignment_map_path`: (alignment mode) JSON file mapping conserved alignment positions to node indices per structure.
+- `--alignment_margin`: (alignment mode) cosine margin applied to negative node pairs.
+- `--alignment_unaligned_per_graph`: (alignment mode) number of unaligned nodes sampled from each structure as negatives.
+
+All other arguments (hidden dimensions, pooling, sequencing weight, etc.) remain available for advanced configuration. See
+`ginfinity-train --help` for the exhaustive list generated from `train_model.py`.
 
 ---
 

--- a/src/ginfinity/training/__init__.py
+++ b/src/ginfinity/training/__init__.py
@@ -1,1 +1,2 @@
-from .gin_rna_dataset import GINRNADataset, GINRNAPairDataset
+from .gin_rna_dataset import GINRNADataset, GINRNAPairDataset, GINAlignmentDataset
+from .alignment_loss import AlignmentContrastiveLoss

--- a/src/ginfinity/training/alignment_loss.py
+++ b/src/ginfinity/training/alignment_loss.py
@@ -1,0 +1,64 @@
+"""Loss utilities for alignment-based training."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class AlignmentContrastiveLoss(nn.Module):
+    """Contrastive loss encouraging aligned nodes to be similar.
+
+    The loss is composed of two terms:
+
+    * ``1 - cos_sim`` for nodes that are annotated as equivalent across
+      different structures (positives).
+    * ``relu(cos_sim - margin)`` for nodes annotated with different
+      alignment positions (negatives).
+
+    Parameters
+    ----------
+    margin:
+        Cosine similarity margin used for negative pairs. Similarities above
+        ``margin`` are penalized while smaller similarities receive no
+        penalty.
+    """
+
+    def __init__(self, margin: float = 0.0):
+        super().__init__()
+        self.margin = float(margin)
+
+    def forward(
+        self,
+        embeddings: torch.Tensor,
+        labels: torch.Tensor,
+        graph_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        if embeddings.numel() == 0 or embeddings.shape[0] < 2:
+            # Return a zero scalar that participates in autograd.
+            return embeddings.sum() * 0.0
+
+        # Normalize before computing cosine similarity.
+        embeddings = F.normalize(embeddings, p=2, dim=1)
+        sim_matrix = embeddings @ embeddings.t()
+
+        same_graph = graph_ids.unsqueeze(0) == graph_ids.unsqueeze(1)
+        same_label = labels.unsqueeze(0) == labels.unsqueeze(1)
+
+        different_graphs = ~same_graph
+        positive_mask = same_label & different_graphs
+        negative_mask = (~same_label) & different_graphs
+
+        loss = torch.zeros((), device=embeddings.device, dtype=embeddings.dtype)
+
+        if positive_mask.any():
+            pos_sims = sim_matrix[positive_mask]
+            loss = loss + (1.0 - pos_sims).mean()
+
+        if negative_mask.any():
+            neg_sims = sim_matrix[negative_mask]
+            penalties = F.relu(neg_sims - self.margin)
+            loss = loss + penalties.mean()
+
+        return loss


### PR DESCRIPTION
## Summary
- add a dataset and contrastive loss for conserved alignment nodes
- extend the training script with an `alignment` mode and CLI options
- document the new training workflow in the scripts README

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d15eb12fe48326bfe409b15e61a09d