### PR TITLE
Optimize alignment pipeline for FORGI graphs

### DIFF
--- a/src/ginfinity/scripts/train_model.py
+++ b/src/ginfinity/scripts/train_model.py
@@ -722,9 +722,12 @@ def main():
     device = args.device
 
     # Initialize GIN model with processed hidden_dim
-    loop_feature_dim = 2  # loop size + relative position
+    if args.graph_encoding == "forgi":
+        structural_dim = 1 + 4 + 2  # paired flag, loop category one-hot, loop metrics
+    else:
+        structural_dim = 1 + 2  # paired flag + loop metrics
     base_feature_dim = 4 if args.seq_weight > 0 else 0
-    node_feature_dim = 1 + loop_feature_dim + base_feature_dim
+    node_feature_dim = structural_dim + base_feature_dim
     model = GINModel(
         hidden_dim=hidden_dim,
         output_dim=args.output_dim,


### PR DESCRIPTION
## Summary
- add a `structure_to_data` helper that builds FORGI-inspired node features and reuses cached graph tensors
- update RNA training datasets to reuse preprocessed structures and support the new conversion path
- expose graph-encoding controls in embedding scripts and adjust training feature dims for FORGI mode

## Testing
- `python -m compileall src/ginfinity`


------
https://chatgpt.com/codex/tasks/task_e_68d685d50f648326a099e3efa294080c